### PR TITLE
Explicitly set Scylla CPUs and flag for shared host

### DIFF
--- a/config/scylla/scylla1.yml
+++ b/config/scylla/scylla1.yml
@@ -3,12 +3,14 @@ version: "3.9"
 services:
   scylla:
     image: "scylladb/scylla:5.1.0"
+    cpu_count: 4
     command:
       [
         "--developer-mode",
         "0",
         "--smp",
         "4",
+        "--overprovisioned",
         "--listen-address",
         "10.0.1.7",
         "--seeds",

--- a/config/scylla/scylla2.yml
+++ b/config/scylla/scylla2.yml
@@ -3,12 +3,14 @@ version: "3.9"
 services:
   scylla:
     image: "scylladb/scylla:5.1.0"
+    cpu_count: 4
     command:
       [
         "--developer-mode",
         "0",
         "--smp",
         "4",
+        "--overprovisioned",
         "--listen-address",
         "10.0.1.8",
         "--seeds",


### PR DESCRIPTION
Since we're using SMP 4, Docker should enforce that 4 CPUs are available. While this isn't sharing Scylla on the same host, the host still has shared resources since it's a VM so we enable the `overprovisioned` optimisations.